### PR TITLE
Fix background stealing the click event

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -4,6 +4,8 @@ export class Background {
         const el = element instanceof HTMLElement ? element : document.createElement('div');
      
         el.classList += ` rete-background ${element === true ? 'default' : ''}`;
+        el.addEventListener('click', e => editor.trigger({e, container: editor.view.container}));
+        
         editor.view.area.appendChild(el);
     }
 }


### PR DESCRIPTION
Currently, `editor.on('click', ...)` doesn't work with AreaPlugin enabled because the click event gets stolen by the background element.
This pull request adds an event listener that propagetes the click event to the editor.