### PR TITLE
feat: add Meta key support for accumulation function

### DIFF
--- a/src/extensions/selectable.ts
+++ b/src/extensions/selectable.ts
@@ -11,10 +11,10 @@ export function accumulateOnCtrl() {
   let pressed = false
 
   function keydown(e: KeyboardEvent) {
-    if (e.key === 'Control') pressed = true
+    if (e.key === 'Control' || e.key === 'Meta') pressed = true
   }
   function keyup(e: KeyboardEvent) {
-    if (e.key === 'Control') pressed = false
+    if (e.key === 'Control' || e.key === 'Meta') pressed = false
   }
 
   document.addEventListener('keydown', keydown)


### PR DESCRIPTION
The accumulation function now recognizes `Meta` key presses in addition to the `Control` key. This change enhances cross-platform compatibility, particularly for Mac users who use the `Meta` key for similar operations.

### Description

This update modifies the accumulation function to detect Meta key presses, in addition to the existing Control key support. The primary motivation behind this change is to improve the user experience for Mac users, where the Meta key (often the Command key) is frequently used for operations similar to those performed with the Control key on other platforms.


### Checklist

<!-- Mark the items that apply to this pull request -->

- [x] I have read and followed [the contribution guidelines](https://retejs.org/docs/contribution#contribution).
- [x] I have [tested my changes](https://github.com/retejs/rete-qa) locally.
- [ ] I have updated [documentation](https://github.com/retejs/retejs.org) accordingly (if necessary).
- [ ] I have added unit and [E2E](https://github.com/retejs/rete-qa) tests (if applicable).
