### PR TITLE
fix: prevent error on removing if the holder has been cleared

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -32,6 +32,8 @@ export class Content {
   }
 
   remove(element: HTMLElement) {
-    this.holder.removeChild(element)
+    if (this.holder.contains(element)) {
+      this.holder.removeChild(element)
+    }
   }
 }


### PR DESCRIPTION
### Related Issues

https://github.com/retejs/connection-reroute-plugin/issues/37

### Checklist

<!-- Mark the items that apply to this pull request -->

- [x] I have read and followed [the contribution guidelines](https://retejs.org/docs/contribution#contribution).
- [x] I have [tested my changes](https://github.com/retejs/rete-qa) locally.
- [ ] I have updated [documentation](https://github.com/retejs/retejs.org) accordingly (if necessary).
- [ ] I have added unit and [E2E](https://github.com/retejs/rete-qa) tests (if applicable).
