### PR TITLE
fix: prevent zooming out when horizontal wheel is rotated

### DIFF
--- a/src/zoom.ts
+++ b/src/zoom.ts
@@ -36,10 +36,7 @@ export class Zoom {
     e.preventDefault()
 
     const { left, top } = this.element.getBoundingClientRect()
-    const isNegative = e.deltaY < 0
-    const delta = isNegative
-      ? this.intensity
-      : -this.intensity
+    const delta = -this.intensity * Math.sign(e.deltaY);
     const ox = (left - e.clientX) * delta
     const oy = (top - e.clientY) * delta
 


### PR DESCRIPTION
### Description

This PR prevents the view from zooming out when the wheel event deltaY is 0.
Previously, using a horizontal mouse wheel would incorrectly trigger a zoom-out action.

### Related Issues

<!-- If your pull request is related to any GitHub issue(s), mention them here. -->

### Checklist

<!-- Mark the items that apply to this pull request -->

- [x] I have read and followed [the contribution guidelines](https://retejs.org/docs/contribution#contribution).
- [x] I have [tested my changes](https://github.com/retejs/rete-qa) locally.
- [x] I have updated [documentation](https://github.com/retejs/retejs.org) accordingly (if necessary).
- [x] I have added unit and [E2E](https://github.com/retejs/rete-qa) tests (if applicable).

### Additional Notes

<!-- Any additional information or notes for the reviewers. -->
